### PR TITLE
Use venv to avoid issue on reinstalling an other version of c2cciutils in audit workflow

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -23,11 +23,23 @@ jobs:
           ref: ${{ matrix.branch }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - run: echo "${HOME}/.local/bin" >> ${GITHUB_PATH}
-      - run: python3 -m pip install --user --pre c2cciutils[audit]
+      - run: python3 -m venv ~/.venv
+      - run: ~/.venv/bin/pip install --pre c2cciutils[audit]
+      - run: python3 -m pip install --pre c2cciutils[audit]
+
+      - name: Check .tool-versions file existence
+        id: tool-versions
+        uses: andstor/file-existence-action@v1
+        with:
+          files: .tool-versions
+      - uses: asdf-vm/actions/install@v1
+        if: steps.tool-versions.outputs.files_exists == 'true'
+      - run: cat /tmp/python-build.*.log
+        if: failure()
+      - run: python --version
 
       - name: Audit
-        run: c2cciutils-audit --branch=${{ matrix.branch }}
+        run: ~/.venv/bin/c2cciutils-audit --branch=${{ matrix.branch }}
         env:
           GITHUB_TOKEN: ${{ github.token }}
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -29,6 +29,8 @@ jobs:
 
       - name: Checks
         run: c2cciutils-checks
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 
       - name: Build
         run: docker build --tag=${GITHUB_REPOSITORY} .
@@ -39,3 +41,5 @@ jobs:
       - name: Publish
         run: c2cciutils-publish
         if: env.HAS_SECRETS == 'HAS_SECRETS'
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/ci/config.yaml
+++ b/ci/config.yaml
@@ -5,13 +5,6 @@ version:
     - from: master
       to: latest
 
-checks:
-  required_workflows:
-    clean.yaml: false
-  codespell:
-    ignore_re:
-      - ^poetry.lock$
-
 publish:
   pypi:
     packages: []

--- a/ci/requirements.txt
+++ b/ci/requirements.txt
@@ -1,1 +1,1 @@
-c2cciutils[checks,publish]==1.3.7
+c2cciutils[checks,publish]==1.4.0.dev121


### PR DESCRIPTION
- Add the required token for Snyk
- Lock file maintenance
- Fix the checkout user to be able to create pull request for Snyk fix
- Use venv to avoid issue on reinstalling an other version of c2cciutils in audit workflow
